### PR TITLE
updating the deprecated compute cluster spark-version and node-type

### DIFF
--- a/.github/workflows/onMainPullRequest.yaml
+++ b/.github/workflows/onMainPullRequest.yaml
@@ -43,8 +43,7 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "13.2.x-cpu-ml-scala2.12",
-             "node_type_id": "Standard_DS3_v2"
+
            }
            
   run-integration-tests:
@@ -69,6 +68,5 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "13.2.x-cpu-ml-scala2.12",
-             "node_type_id": "Standard_DS3_v2"
+             
            }

--- a/.github/workflows/onMainPullRequest.yaml
+++ b/.github/workflows/onMainPullRequest.yaml
@@ -43,8 +43,8 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "11.3.x-scala2.12",
-             "node_type_id": "i3.xlarge"
+             "spark_version": "13.2.x-cpu-ml-scala2.12",
+             "node_type_id": "Standard_DS3_v2"
            }
            
   run-integration-tests:
@@ -69,6 +69,6 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "11.3.x-scala2.12",
-             "node_type_id": "i3.xlarge"
+             "spark_version": "13.2.x-cpu-ml-scala2.12",
+             "node_type_id": "Standard_DS3_v2"
            }

--- a/.github/workflows/onPullRequest.yml
+++ b/.github/workflows/onPullRequest.yml
@@ -42,6 +42,5 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "13.2.x-cpu-ml-scala2.12",
-             "node_type_id": "Standard_DS3_v2"
+             
            }

--- a/.github/workflows/onPullRequest.yml
+++ b/.github/workflows/onPullRequest.yml
@@ -42,6 +42,6 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "11.3.x-scala2.12",
-             "node_type_id": "i3.xlarge"
+             "spark_version": "13.2.x-cpu-ml-scala2.12",
+             "node_type_id": "Standard_DS3_v2"
            }

--- a/.github/workflows/onPushRequest.yml
+++ b/.github/workflows/onPushRequest.yml
@@ -42,8 +42,8 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "11.3.x-scala2.12",
-             "node_type_id": "i3.xlarge"
+             "spark_version": "13.2.x-cpu-ml-scala2.12",
+             "node_type_id": "Standard_DS3_v2"
            }
            
   run-integration-tests:
@@ -68,6 +68,6 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "11.3.x-scala2.12",
-             "node_type_id": "i3.xlarge"
+             "spark_version": "13.2.x-cpu-ml-scala2.12",
+             "node_type_id": "Standard_DS3_v2"
            }

--- a/.github/workflows/onPushRequest.yml
+++ b/.github/workflows/onPushRequest.yml
@@ -42,8 +42,7 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "13.2.x-cpu-ml-scala2.12",
-             "node_type_id": "Standard_DS3_v2"
+             
            }
            
   run-integration-tests:
@@ -68,6 +67,5 @@ jobs:
          new-cluster-json: >
            {
              "num_workers": 1,
-             "spark_version": "13.2.x-cpu-ml-scala2.12",
-             "node_type_id": "Standard_DS3_v2"
+             
            }


### PR DESCRIPTION
to latest spark version 13.2.x-cpu-ml  and node type Standard_DS3_v2 in .github/workflows